### PR TITLE
Bump version to 0.4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nebius"
-version = "0.4.2"
+version = "0.4.3"
 description = "Nebius Python SDK"
 authors = [
     { name = "Daniil Drizhuk", email = "complynx@nebius.com" },

--- a/src/nebius/base/version.py
+++ b/src/nebius/base/version.py
@@ -1,4 +1,4 @@
 """Nebius SDK version information."""
 
-version = "0.4.2"
+version = "0.4.3"
 """Current Nebius SDK version string."""


### PR DESCRIPTION
## Summary

- bump the package version from 0.4.2 to 0.4.3
- keep `pyproject.toml` and `src/nebius/base/version.py` in sync

## Why

Prepare a patch release containing the changes merged since `v0.4.2`.

## Impact

Once merged and tagged as `v0.4.3`, the tag-triggered release workflow will publish the package to PyPI and deploy the generated documentation.

## Validation

- version updater reports `0.4.3`
- package source distribution builds as `nebius-0.4.3.tar.gz`
- pre-commit hooks pass (Black, Ruff, EOF, trailing whitespace)
- `git diff --check` passes

The full local pytest command was not used as a release gate because this workspace contains an ignored generated test under `target/` that fails collection against the current generated API; CI will run from a clean checkout.
